### PR TITLE
(feat) allow to create producer when selecting non-existent one

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,6 +19,12 @@ Primarily a stabilization and bug-fix release.
 - [[https://github.com/d12frosted/vino/pull/84][vino#84]] Fix invalid vintage in rating title both in =vino-rating--create= and
   =vino-entry-update-title=.
 
+*Features*
+
+- [[https://github.com/d12frosted/vino/pull/85][vino#85]] Allow to create producer note when selecting non-existent producer.
+  Affects =vino-producer-select=, =vino-producer-find-file= and
+  =vino-entry-create=.
+
 ** v0.1
 :PROPERTIES:
 :ID:                     81aaf405-b49b-4b96-811d-fb6989e6a26f

--- a/test/vino-test.el
+++ b/test/vino-test.el
@@ -397,6 +397,7 @@
              :id id))))
 
 (describe "vino-producer-select"
+  :var (id ts)
   (before-all
     (vino-test--init))
 
@@ -413,7 +414,26 @@
              :title "Arianna Occhipinti"
              :tags '("wine" "producer")
              :level 0
-             :id "9462dfad-603c-4094-9aca-a9042cec5dd2"))))
+             :id "9462dfad-603c-4094-9aca-a9042cec5dd2")))
+
+  (it "creates a new producer note when selecting non-existing name"
+    (setq id (org-id-new)
+          ts (current-time))
+    (spy-on 'org-id-new :and-return-value id)
+    (spy-on 'current-time :and-return-value ts)
+    (spy-on 'org-roam-completion--completing-read :and-return-value "Vino di Anna")
+    (spy-on 'y-or-n-p :and-return-value t)
+    (expect (vino-producer-select)
+            :to-equal
+            (make-vulpea-note
+             :path (expand-file-name
+                    (format "wine/producer/%s-vino_di_anna.org"
+                            (format-time-string "%Y%m%d%H%M%S" ts))
+                    org-roam-directory)
+             :title "Vino di Anna"
+             :tags '("wine" "producer")
+             :level 0
+             :id id))))
 
 (describe "vino-region-create"
   :var (id ts)

--- a/vino.el
+++ b/vino.el
@@ -958,26 +958,33 @@ Return `vulpea-note'."
 (defun vino-producer-find-file ()
   "Select and find producer note."
   (interactive)
-  (let ((res (vino-producer-select)))
-    (if (vulpea-note-id res)
-        (find-file (vulpea-note-path res))
-      (user-error
-       "Can not visit producer entry that does not exist: %s"
-       (vulpea-note-title res)))))
+  (when-let* ((note (vino-producer-select))
+              (path (vulpea-note-path note)))
+    (find-file path)))
 
 ;;;###autoload
 (defun vino-producer-select ()
   "Select a producer note.
 
+When producer note does not exist, it is created using
+`vino-producer-create' if user decides to do so.
+
 See `vulpea' documentation for more information on note
 structure."
-  (vulpea-select
-   "Producer"
-   nil nil
-   (lambda (note)
-     (let ((tags (vulpea-note-tags note)))
-       (and (seq-contains-p tags "wine")
-            (seq-contains-p tags "producer"))))))
+  (let ((note (vulpea-select
+               "Producer"
+               nil nil
+               (lambda (note)
+                 (let ((tags (vulpea-note-tags note)))
+                   (and (seq-contains-p tags "wine")
+                        (seq-contains-p tags "producer")))))))
+    (if (vulpea-note-id note)
+        note
+      (if (y-or-n-p
+           (format "Producer %s does not exist. Create it? "
+                   (vulpea-note-title note)))
+          (vino-producer-create (vulpea-note-title note))
+        note))))
 
 
 ;;; Price


### PR DESCRIPTION
Affects `vino-producer-select`, `vino-producer-find-file` and
`vino-entry-create`.