### PR TITLE
(feat) allow to create region when selecting non-existent one

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -27,6 +27,9 @@ Primarily a stabilization and bug-fix release.
 - [[https://github.com/d12frosted/vino/pull/86][vino#86]] Align behaviour of =vino-grape-select= with =vino-producer-select=, so
   the user is prompted to create a note when selecting a non-existent grape
   note.
+- [[https://github.com/d12frosted/vino/pull/86][vino#86]] Allow to create region or appellation note when selecting non-existent
+  region or appellation. Affects =vino-region-select=, =vino-region-find-file=
+  and =vino-entry-create=.
 
 ** v0.1
 :PROPERTIES:

--- a/test/vino-test.el
+++ b/test/vino-test.el
@@ -487,6 +487,7 @@
              :id id))))
 
 (describe "vino-region-select"
+  :var (id ts)
   (before-all
     (vino-test--init))
 
@@ -515,7 +516,47 @@
              :title "Cerasuolo di Vittoria DOCG"
              :tags '("wine" "appellation")
              :level 0
-             :id "6a0819f3-0770-4481-9754-754ca397800b"))))
+             :id "6a0819f3-0770-4481-9754-754ca397800b")))
+
+  (it "creates a new region note when selecting non-existing name"
+    (setq id (org-id-new)
+          ts (current-time))
+    (spy-on 'org-id-new :and-return-value id)
+    (spy-on 'current-time :and-return-value ts)
+    (spy-on 'org-roam-completion--completing-read :and-return-value "Codru")
+    (spy-on 'completing-read :and-return-value "Create region")
+    (spy-on 'read-string :and-return-value "")
+    (expect (vino-region-select)
+            :to-equal
+            (make-vulpea-note
+             :path (expand-file-name
+                    (format "wine/region/%s-codru.org"
+                            (format-time-string "%Y%m%d%H%M%S" ts))
+                    org-roam-directory)
+             :title "Codru"
+             :tags '("wine" "region")
+             :level 0
+             :id id)))
+
+  (it "creates a new appellation note when selecting non-existing name"
+    (setq id (org-id-new)
+          ts (current-time))
+    (spy-on 'org-id-new :and-return-value id)
+    (spy-on 'current-time :and-return-value ts)
+    (spy-on 'org-roam-completion--completing-read :and-return-value "Gattinara DOCG")
+    (spy-on 'completing-read :and-return-value "Create appellation")
+    (spy-on 'read-string :and-return-value "")
+    (expect (vino-region-select)
+            :to-equal
+            (make-vulpea-note
+             :path (expand-file-name
+                    (format "wine/appellation/%s-gattinara_docg.org"
+                            (format-time-string "%Y%m%d%H%M%S" ts))
+                    org-roam-directory)
+             :title "Gattinara DOCG"
+             :tags '("wine" "appellation")
+             :level 0
+             :id id))))
 
 (describe "vino-entry-consume"
   :var ((id "c9937e3e-c83d-4d8d-a612-6110e6706252")


### PR DESCRIPTION
Affects `vino-region-select`, `vino-region-find-file` and
`vino-region-create`.