### PR TITLE
(fix) require match in vino-entry-note-select

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,6 +19,8 @@ Primarily a stabilization and bug-fix release.
 - [[https://github.com/d12frosted/vino/pull/84][vino#84]] Fix invalid vintage in rating title both in =vino-rating--create= and
   =vino-entry-update-title=.
 - [[https://github.com/d12frosted/vino/pull/89][vino#89]] Add missing =autoload= comments.
+- [[https://github.com/d12frosted/vino/pull/92][vino#92]] Do not allow to select vino entry that does not exist in
+  =vino-entry-note-select=.
 
 *Features*
 

--- a/vino.el
+++ b/vino.el
@@ -311,12 +311,7 @@ Variables in the capture context are provided by
 (defun vino-entry-find-file ()
   "Select and find vino note."
   (interactive)
-  (let ((res (vino-entry-note-select)))
-    (if (vulpea-note-id res)
-        (find-file (vulpea-note-path res))
-      (user-error
-       "Can not visit vino entry that does not exist: %s"
-       (vulpea-note-title res)))))
+  (find-file (vulpea-note-path (vino-entry-note-select))))
 
 ;;;###autoload
 (defun vino-entry-read ()
@@ -838,12 +833,7 @@ Return `vulpea-note'."
 (defun vino-region-find-file ()
   "Select and find region note."
   (interactive)
-  (if-let* ((note (vino-region-select))
-            (path (vulpea-note-path note)))
-      (find-file path)
-    (user-error
-     "Can not visit region entry that does not exist: %s"
-     (vulpea-note-title note))))
+  (find-file (path (vulpea-note-path (vino-region-select)))))
 
 ;;;###autoload
 (defun vino-region-select ()
@@ -914,12 +904,7 @@ Return `vulpea-note'."
 (defun vino-grape-find-file ()
   "Select and find grape note."
   (interactive)
-  (if-let* ((note (vino-grape-select))
-            (path (vulpea-note-path note)))
-      (find-file path)
-    (user-error
-     "Can not visit grape entry that does not exist: %s"
-     (vulpea-note-title note))))
+  (find-file (vulpea-note-path (vino-grape-select))))
 
 ;;;###autoload
 (defun vino-grape-select ()
@@ -982,12 +967,7 @@ Return `vulpea-note'."
 (defun vino-producer-find-file ()
   "Select and find producer note."
   (interactive)
-  (if-let* ((note (vino-producer-select))
-            (path (vulpea-note-path note)))
-      (find-file path)
-    (user-error
-     "Can not visit region entry that does not exist: %s"
-     (vulpea-note-title note))))
+  (find-file (vulpea-note-path (vino-producer-select))))
 
 ;;;###autoload
 (defun vino-producer-select ()

--- a/vino.el
+++ b/vino.el
@@ -725,6 +725,7 @@ explicitly."
   "Select and return a `vulpea-note' representing `vino-entry'."
   (vulpea-select
    "Wine"
+   :require-match t
    :filter-fn
    (lambda (note)
      (let ((tags (vulpea-note-tags note)))


### PR DESCRIPTION
All usages of this function expect existing note as a result. They
either check for existence manually or hope for the best.