### PR TITLE
(dev) create custom matcher for `vulpea-note`

### DIFF
--- a/test/utils/vino-test-utils.el
+++ b/test/utils/vino-test-utils.el
@@ -122,7 +122,7 @@ LINKS (optional) is list of (type . link) pairs."
     (make-vulpea-note
      :path path
      :title title
-     :tags (or tags (list type "wine"))
+     :tags (or tags (list "wine" type))
      :level 0
      :id id
      :links links

--- a/test/utils/vino-test-utils.el
+++ b/test/utils/vino-test-utils.el
@@ -194,6 +194,64 @@ now."
                    "Expected `%F' to have content equal to `%v', but instead `%F' has content equal to `%c'"
                    spec))))))
 
+(defun buttercup-enclose (args)
+  "Simply enclose ARGS for `buttercup' usage."
+  (mapcar
+   (lambda (expr) (lambda () expr))
+   args))
+
+(defun buttercup-and (&rest args)
+  "Combine matcher results represented as ARGS into one."
+  (or (seq-every-p #'car args)
+      (seq-find (lambda (a) (not (car a))) args)))
+
+(buttercup-define-matcher :to-be-note (a b)
+  (cl-destructuring-bind
+      ((_ . a) (_ . b))
+      (mapcar #'buttercup--expr-and-value (list a b))
+    (let ((a-id (vulpea-note-id a))
+          (a-path (vulpea-note-path a))
+          (a-level (vulpea-note-level a))
+          (a-title (vulpea-note-title a))
+          (a-primary-title (vulpea-note-primary-title a))
+          (a-aliases (vulpea-note-aliases a))
+          (a-tags (vulpea-note-tags a))
+          (a-links (vulpea-note-links a))
+          (a-properties (vulpea-note-properties a))
+          (a-meta (vulpea-note-meta a))
+          ;; b
+          (b-id (vulpea-note-id b))
+          (b-path (vulpea-note-path b))
+          (b-level (vulpea-note-level b))
+          (b-title (vulpea-note-title b))
+          (b-primary-title (vulpea-note-primary-title b))
+          (b-aliases (vulpea-note-aliases b))
+          (b-tags (vulpea-note-tags b))
+          (b-links (vulpea-note-links b))
+          (b-properties (vulpea-note-properties b))
+          (b-meta (vulpea-note-meta b)))
+      (buttercup-and
+       (buttercup--apply-matcher
+        :to-equal (buttercup-enclose (list a-id b-id)))
+       (buttercup--apply-matcher
+        :to-equal (buttercup-enclose (list a-path b-path)))
+       (buttercup--apply-matcher
+        :to-equal (buttercup-enclose (list a-level b-level)))
+       (buttercup--apply-matcher
+        :to-equal (buttercup-enclose (list a-title b-title)))
+       (buttercup--apply-matcher
+        :to-equal (buttercup-enclose (list a-primary-title b-primary-title)))
+       (buttercup--apply-matcher
+        :to-have-same-items-as (buttercup-enclose (list a-aliases b-aliases)))
+       (buttercup--apply-matcher
+        :to-have-same-items-as (buttercup-enclose (list a-tags b-tags)))
+       (buttercup--apply-matcher
+        :to-have-same-items-as (buttercup-enclose (list a-links b-links)))
+       (buttercup--apply-matcher
+        :to-have-same-items-as (buttercup-enclose (list a-properties b-properties)))
+       (buttercup--apply-matcher
+        :to-have-same-items-as (buttercup-enclose (list a-meta b-meta)))))))
+
 
 
 (defmacro vino-spy--return-values (res values orig-initform)

--- a/test/vino-test.el
+++ b/test/vino-test.el
@@ -78,10 +78,10 @@
              :id "c9937e3e-c83d-4d8d-a612-6110e6706252"
              :title "Arianna Occhipinti Bombolieri BB 2017"
              :basename "c9937e3e-c83d-4d8d-a612-6110e6706252"
-             :links '(("http" . "http://www.agricolaocchipinti.it/it/vinicontrada")
+             :links '(("id" . "9462dfad-603c-4094-9aca-a9042cec5dd2")
                       ("id" . "8353e2fc-8034-4540-8254-4b63fb5a421a")
-                      ("id" . "9462dfad-603c-4094-9aca-a9042cec5dd2")
-                      ("id" . "cb1eb3b9-6233-4916-8c05-a3a4739e0cfa"))
+                      ("id" . "cb1eb3b9-6233-4916-8c05-a3a4739e0cfa")
+                      ("http" . "http://www.agricolaocchipinti.it/it/vinicontrada"))
              :meta '(("carbonation" "still")
                      ("colour" "red")
                      ("sweetness" "dry")
@@ -412,8 +412,8 @@
              :type "appellation"
              :id "6a0819f3-0770-4481-9754-754ca397800b"
              :title "Cerasuolo di Vittoria DOCG"
-             :links '(("id" . "3b38917f-6065-42e8-87ca-33dd39a92fc0")
-                      ("id" . "cb1eb3b9-6233-4916-8c05-a3a4739e0cfa")))))
+             :links '(("id" . "cb1eb3b9-6233-4916-8c05-a3a4739e0cfa")
+                      ("id" . "3b38917f-6065-42e8-87ca-33dd39a92fc0")))))
 
   (it "creates a new region note when selecting non-existing name"
     (spy-on 'completing-read :and-return-values '("Codru" "Create region"))

--- a/test/vino-test.el
+++ b/test/vino-test.el
@@ -72,7 +72,7 @@
      (completion-for :title "Arianna Occhipinti Bombolieri BB 2017"
                      :tags '("cellar")))
     (expect (vino-entry-note-select)
-            :to-equal
+            :to-be-note
             (mk-vulpea-note
              :type "cellar"
              :id "c9937e3e-c83d-4d8d-a612-6110e6706252"
@@ -282,7 +282,7 @@
 
   (it "creates a new grape note"
     (expect (mock-vulpea-note :type "grape" :title "Slarina")
-            :to-equal
+            :to-be-note
             (vino-grape-create "Slarina"))))
 
 (describe "vino-grape-select"
@@ -296,7 +296,7 @@
      (completion-for :title "Frappato"
                      :tags '("grape")))
     (expect (vino-grape-select)
-            :to-equal
+            :to-be-note
             (mk-vulpea-note
              :type "grape"
              :id "cb1eb3b9-6233-4916-8c05-a3a4739e0cfa"
@@ -305,7 +305,7 @@
   (it "creates a new grape note when selecting non-existing name"
     (spy-on 'completing-read :and-return-values '("Slarina" "Create new grape"))
     (expect (mock-vulpea-note :type "grape" :title "Slarina")
-            :to-equal
+            :to-be-note
             (vino-grape-select)))
 
   (it "adds a synonym when selecting non-existing name"
@@ -316,7 +316,7 @@
              "Add a synonym to existing grape"
              (completion-for :title "Frappato" :tags '("grape"))))
     (expect (vino-grape-select)
-            :to-equal
+            :to-be-note
             (mk-vulpea-note :type "grape"
                             :id "cb1eb3b9-6233-4916-8c05-a3a4739e0cfa"
                             :title "Frappato di Vittoria"
@@ -338,7 +338,7 @@
 
   (it "creates a new producer note"
     (expect (mock-vulpea-note :type "producer" :title "Vino di Anna")
-            :to-equal
+            :to-be-note
             (vino-producer-create "Vino di Anna")
             )))
 
@@ -353,7 +353,7 @@
      (completion-for :title "Arianna Occhipinti"
                      :tags '("producer")))
     (expect (vino-producer-select)
-            :to-equal
+            :to-be-note
             (mk-vulpea-note
              :type "producer"
              :id "9462dfad-603c-4094-9aca-a9042cec5dd2"
@@ -366,7 +366,7 @@
      "Vino di Anna")
     (spy-on 'y-or-n-p :and-return-value t)
     (expect (mock-vulpea-note :type "producer" :title "Vino di Anna")
-            :to-equal
+            :to-be-note
             (vino-producer-select))))
 
 (describe "vino-region-create"
@@ -375,7 +375,7 @@
 
   (it "creates a new region note"
     (expect (mock-vulpea-note :type "region" :title "Codru")
-            :to-equal
+            :to-be-note
             (vino-region-create "Codru"))))
 
 (describe "vino-appellation-create"
@@ -384,7 +384,7 @@
 
   (it "creates a new appellation note"
     (expect (mock-vulpea-note :type "appellation" :title "Gattinara DOCG")
-            :to-equal
+            :to-be-note
             (vino-appellation-create "Gattinara DOCG"))))
 
 (describe "vino-region-select"
@@ -396,7 +396,7 @@
             :and-return-value
             (completion-for :title "Central Otago" :tags '("region")))
     (expect (vino-region-select)
-            :to-equal
+            :to-be-note
             (mk-vulpea-note
              :type "region"
              :id "f9ef759b-f39e-4121-ab19-9ab3daa318be"
@@ -407,7 +407,7 @@
             :and-return-value
             (completion-for :title "Cerasuolo di Vittoria DOCG" :tags '("appellation")))
     (expect (vino-region-select)
-            :to-equal
+            :to-be-note
             (mk-vulpea-note
              :type "appellation"
              :id "6a0819f3-0770-4481-9754-754ca397800b"
@@ -419,14 +419,14 @@
     (spy-on 'completing-read :and-return-values '("Codru" "Create region"))
     (spy-on 'read-string :and-return-value "")
     (expect (mock-vulpea-note :type "region" :title "Codru")
-            :to-equal
+            :to-be-note
             (vino-region-select)))
 
   (it "creates a new appellation note when selecting non-existing name"
     (spy-on 'completing-read :and-return-values '("Gattinara DOCG" "Create appellation"))
     (spy-on 'read-string :and-return-value "")
     (expect (mock-vulpea-note :type "appellation" :title "Gattinara DOCG")
-            :to-equal
+            :to-be-note
             (vino-region-select))))
 
 (describe "vino-entry-consume"


### PR DESCRIPTION
Not ideal, but at least removes the need to shuffle around elements in
some lists (like tags and links) where order is not well defined.
