### PR TITLE
dev: fix buttercup-format-spec for Emacs29+

### DIFF
--- a/test/utils/vino-test-utils.el
+++ b/test/utils/vino-test-utils.el
@@ -37,6 +37,17 @@
 (require 'buttercup)
 (require 'dash)
 
+(when (version<= "29" emacs-version)
+  (defun buttercup-format-spec (format specification)
+    "Return a string based on FORMAT and SPECIFICATION.
+
+This is a wrapper around `format-spec', which see. This also adds
+a call to `save-match-data', as `format-spec' modifies that."
+    (save-match-data
+      (format-spec format (--map
+                           (cons (car it) (lambda () (cdr it)))
+                           specification)))))
+
 
 
 (defvar vino-test-directory (expand-file-name "test/note-files")


### PR DESCRIPTION
It's a temporary measure, the proper fix should land in buttercup