### PR TITLE
feat: move volume property from bottle to wine entry

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -8,6 +8,7 @@
 - Define =vino-entry-meta-props-order= as =var= and not a =const=.
 - Fix average score calculation using =amean= strategy.
 - Use =vulpea-select-multiple-from= when selecting grapes to avoid repetition.
+- Move =volume= property from bottle to wine entry.
 
 ** v0.4.0
 

--- a/vino.el
+++ b/vino.el
@@ -516,6 +516,7 @@ resulting rating is still rounded to respect `vino-rating-precision'.")
     "base"
     "sur lie"
     "degorgee"
+    "volume"
     "country"
     "region"
     "appellation"
@@ -624,6 +625,10 @@ note as the only argument."
                        (if (string-empty-p x)
                            "N/A"
                          x))))
+         (volume (vino--repeat-while
+                   #'read-number
+                   (lambda (v) (< v 1))
+                   "Volume (ml): "))
          (origin (funcall-interactively vino-origin-select-fn))
          (grapes (vino-grapes-select))
          (alcohol (vino--repeat-while
@@ -661,7 +666,8 @@ note as the only argument."
                          ("vintage" . ,vintage)
                          ("base" . ,base-vintage)
                          ("sur lie" . ,sur-lie)
-                         ("degorgee" . ,degorgee))
+                         ("degorgee" . ,degorgee)
+                         ("volume" . ,volume))
                         origin
                         `(("grapes" . ,grapes)
                           ("alcohol" . ,alcohol)


### PR DESCRIPTION
Aside from giving a way to reflect the mere fact that some wines come in very specific bottle sizes (think of Radikon, Marsala, etc.), it also allows to distinguish wines of different size: price and rating-wise. And indeed, magnum bottles are often quite different - not only they do have their own evolution compared to normal bottles, sometimes they are even crafted differently (a common thing within Champagne).

So practically, thus also means that one should create separate wine entries for different volumes.

P.S. If you have troubles migrating, simply run the following SQL:

```sql
ALTER TABLE bottle DROP COLUMN volume;
```

There is no migration routine as I haven't seen users of `vino-inv` yet.