### PR TITLE
feat: add vino-entry-copy to create wine entry from existing

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -6,6 +6,7 @@
 
 - Upgrade =vino-inv= module to Vulpea v2.
 - Enable alias expansion in all selection functions, allowing search by note aliases.
+- Add =vino-entry-copy= to create a new wine entry by copying an existing one ([[https://github.com/d12frosted/vino/issues/40][#40]]).
 
 *Breaking changes*
 


### PR DESCRIPTION
## Summary

Add `vino-entry-copy` function to create a new wine entry by copying an existing one.

**Copies silently (structural, rarely changes):**
- producer, colour, carbonation, carbonation method, sweetness
- country, region, appellation, grapes

**Prompts with source value as initial input:**
- name, vintage, base vintage, sur lie, degorgee
- volume, alcohol, sugar, price

**Resets to defaults:**
- acquired = 0, consumed = 0, available = 0, rating = "NA"

Closes #40